### PR TITLE
fix bigquery missing datatypes

### DIFF
--- a/bizon/connectors/destinations/bigquery/src/config.py
+++ b/bizon/connectors/destinations/bigquery/src/config.py
@@ -30,8 +30,13 @@ class BigQueryColumnType(str, Enum):
     DATE = "DATE"
     DATETIME = "DATETIME"
     FLOAT = "FLOAT"
+    FLOAT64 = "FLOAT64"
     GEOGRAPHY = "GEOGRAPHY"
     INTEGER = "INTEGER"
+    INT64 = "INT64"
+    NUMERIC = "NUMERIC"
+    BIGNUMERIC = "BIGNUMERIC"
+    JSON = "JSON"
     RECORD = "RECORD"
     STRING = "STRING"
     TIME = "TIME"
@@ -61,8 +66,7 @@ BIGQUERY_TO_POLARS_TYPE_MAPPING = {
     "TIME": pl.Time,
     "GEOGRAPHY": pl.Object,  # Polars doesn't natively support geography types
     "ARRAY": pl.List,  # Requires additional handling for element types
-    "STRUCT": pl.Struct,  # TODO
-    "JSON": pl.Object,  # TODO
+    "JSON": pl.String,
 }
 
 

--- a/bizon/connectors/destinations/bigquery_streaming/src/destination.py
+++ b/bizon/connectors/destinations/bigquery_streaming/src/destination.py
@@ -286,7 +286,7 @@ class BigQueryStreamingDestination(AbstractDestination):
         )
         table.time_partitioning = time_partitioning
 
-        if self.clustering_keys:
+        if self.clustering_keys[self.destination_id]:
             table.clustering_fields = self.clustering_keys[self.destination_id]
         try:
             table = self.bq_client.create_table(table)

--- a/bizon/connectors/sources/kafka/src/source.py
+++ b/bizon/connectors/sources/kafka/src/source.py
@@ -272,7 +272,7 @@ class KafkaSource(AbstractSource):
                     "partition": message.partition(),
                     "timestamp": message.timestamp()[1],
                     "key": message.key().decode("utf-8"),
-                    "headers": {key: value.decode('utf-8') for key, value in message.headers()},
+                    "headers": {key: value.decode('utf-8') for key, value in message.headers()} if message.headers() else {},
                     "value": self.decode(message),
                 }
 


### PR DESCRIPTION
- Add missing BigQuery datatypes: `JSON` `FLOAT64` ...
- Prevent errors while parsing kafka headers