### PR TITLE
chore: store raw data as JSON in BigQuery

### DIFF
--- a/bizon/connectors/destinations/bigquery_streaming/src/destination.py
+++ b/bizon/connectors/destinations/bigquery_streaming/src/destination.py
@@ -96,7 +96,7 @@ class BigQueryStreamingDestination(AbstractDestination):
             return [
                 bigquery.SchemaField("_source_record_id", "STRING", mode="REQUIRED"),
                 bigquery.SchemaField("_source_timestamp", "TIMESTAMP", mode="REQUIRED"),
-                bigquery.SchemaField("_source_data", "STRING", mode="NULLABLE"),
+                bigquery.SchemaField("_source_data", "JSON", mode="NULLABLE"),
                 bigquery.SchemaField("_bizon_extracted_at", "TIMESTAMP", mode="REQUIRED"),
                 bigquery.SchemaField(
                     "_bizon_loaded_at", "TIMESTAMP", mode="REQUIRED", default_value_expression="CURRENT_TIMESTAMP()"
@@ -286,7 +286,7 @@ class BigQueryStreamingDestination(AbstractDestination):
         )
         table.time_partitioning = time_partitioning
 
-        if self.clustering_keys[self.destination_id]:
+        if self.clustering_keys and self.clustering_keys[self.destination_id]:
             table.clustering_fields = self.clustering_keys[self.destination_id]
         try:
             table = self.bq_client.create_table(table)

--- a/tests/destinations/bigquery_streaming/test_bigquery_streaming_client.py
+++ b/tests/destinations/bigquery_streaming/test_bigquery_streaming_client.py
@@ -37,7 +37,7 @@ df_destination_records = pl.DataFrame(
         "bizon_loaded_at": [datetime(2024, 12, 5, 12, 30), datetime(2024, 12, 5, 13, 30)],
         "source_record_id": ["record_1", "record_2"],
         "source_timestamp": [datetime(2024, 12, 5, 11, 30), datetime(2024, 12, 5, 12, 30)],
-        "source_data": ["cookies", "cream"],
+        "source_data": ['{"cookies": 2, "price": 3, "cream": 1}', '{"cookies": 1, "price": 2, "cream": 2}'],
     },
     schema=destination_record_schema,
 )
@@ -49,7 +49,7 @@ def sync_metadata_stream() -> SyncMetadata:
         name="streaming_api",
         job_id="rfou98C9DJH",
         source_name="cookie_test",
-        stream_name="test_stream",
+        stream_name="test_stream_2",
         destination_name="bigquery",
         sync_mode="stream",
     )


### PR DESCRIPTION
- Store Raw JSON data in `_source_data` BQ column as JSON to facilitate and optimize query process