### PR TITLE
chore: pipeline should fail if records increase buffer size

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.8
-
 repos:
   - repo: https://github.com/psf/black
     rev: 24.4.2

--- a/bizon/destination/destination.py
+++ b/bizon/destination/destination.py
@@ -191,6 +191,14 @@ class AbstractDestination(ABC):
         logger.info(
             f"Buffer ripeness {round(self.buffer.ripeness / 60, 2)} min. Max ripeness {round(self.buffer.buffer_flush_timeout / 60, 2)} min."  # noqa
         )
+        logger.info(
+            f"Current records size to process: {round(df_destination_records.estimated_size(unit='b') / 1024 / 1024, 2)} Mb."
+        )
+
+        if df_destination_records.estimated_size(unit="b") > self.buffer.buffer_size:
+            raise ValueError(
+                f"Records size {round(df_destination_records.estimated_size(unit='b') / 1024 / 1024, 2)} Mb is greater than buffer size {round(self.buffer.buffer_size / 1024 / 1024, 2)} Mb. Please increase destination buffer_size or reduce batch_size from the source."
+            )
 
         # Write buffer to destination if buffer is ripe and create a new buffer for the new iteration
         if self.buffer.is_ripe:

--- a/tests/destination/test_destination_logic.py
+++ b/tests/destination/test_destination_logic.py
@@ -66,7 +66,7 @@ def test_buffer_records(logger_destination: LoggerDestination):
     assert logger_destination.buffer.df_destination_records.equals(df_destination_records)
 
 
-def test_write_or_buffer_records(logger_destination: LoggerDestination):
+def test_write_or_buffer_records_too_large(logger_destination: LoggerDestination):
 
     df_big_size = pl.DataFrame(schema=destination_record_schema)
 
@@ -87,11 +87,12 @@ def test_write_or_buffer_records(logger_destination: LoggerDestination):
     logger_destination.buffer.buffer_size = df_big_size.estimated_size(unit="b")
 
     # Write twice
-    buffer_status = logger_destination.write_or_buffer_records(
-        df_destination_records=df_big_size.vstack(df_destination_records), iteration=1
-    )
-
-    assert buffer_status == DestinationBufferStatus.RECORDS_WRITTEN_THEN_BUFFERED
+    with pytest.raises(
+        ValueError, match="Please increase destination buffer_size or reduce batch_size from the source"
+    ):
+        buffer_status = logger_destination.write_or_buffer_records(
+            df_destination_records=df_big_size.vstack(df_destination_records), iteration=1
+        )
 
 
 def test_write_last_iteration(logger_destination: LoggerDestination, sqlite_db_session):


### PR DESCRIPTION
- In case the batch of records has a size that exceeds the full buffer size, we should make the pipeline fail and ask the user to fix config