### PR TITLE
chore: revert to commit consumer for all topics

### DIFF
--- a/bizon/connectors/sources/kafka/src/source.py
+++ b/bizon/connectors/sources/kafka/src/source.py
@@ -266,10 +266,6 @@ class KafkaSource(AbstractSource):
                 logger.debug(
                     f"Message for topic {message.topic()} partition {message.partition()} and offset {message.offset()} is empty, skipping."
                 )
-                # Increment the offset for the partition
-                self.topic_partition_map[message.topic()][message.partition()] = TopicPartition(
-                    topic=message.topic(), partition=message.partition(), offset=message.offset()
-                )
                 continue
 
             # Decode the message
@@ -297,11 +293,6 @@ class KafkaSource(AbstractSource):
                         data=data,
                         destination_id=self.topic_map[message.topic()],
                     )
-                )
-
-                # Cache the last message for the destination_id
-                self.topic_partition_map[message.topic()][message.partition()] = TopicPartition(
-                    topic=message.topic(), partition=message.partition(), offset=message.offset()
                 )
 
             except Exception as e:

--- a/bizon/connectors/sources/kafka/src/source.py
+++ b/bizon/connectors/sources/kafka/src/source.py
@@ -82,9 +82,6 @@ class KafkaSource(AbstractSource):
 
         # Map topic_name to destination_id
         self.topic_map = {topic.name: topic.destination_id for topic in self.config.topics}
-        self.destination_id_map = {topic.destination_id: topic.name for topic in self.config.topics}
-
-        self.topic_partition_map = {topic.name: {} for topic in self.config.topics}
 
     @staticmethod
     def streams() -> List[str]:
@@ -391,16 +388,10 @@ class KafkaSource(AbstractSource):
         else:
             return self.read_topics_manually(pagination)
 
-    def commit(self, destination_id: str):
+    def commit(self):
         """Commit the offsets of the consumer"""
         try:
-            self.consumer.commit(
-                offsets=list(self.topic_partition_map[self.destination_id_map[destination_id]].values()),
-                asynchronous=False,
-            )
-            logger.debug(f"Commited offsets for topic {self.destination_id_map[destination_id]}")
+            self.consumer.commit(asynchronous=False)
         except CimplKafkaException as e:
-            logger.error(
-                f"Kafka exception occurred during commit of {destination_id}, topic: {self.destination_id_map[destination_id]}: {e}"
-            )
+            logger.error(f"Kafka exception occurred during commit: {e}")
             logger.info("Gracefully exiting without committing offsets due to Kafka exception")

--- a/bizon/engine/runner/adapters/streaming.py
+++ b/bizon/engine/runner/adapters/streaming.py
@@ -106,13 +106,13 @@ class StreamingRunner(AbstractRunner):
                         headers=dsm_headers,
                     )
 
-                    if os.getenv("ENVIRONMENT") == "production":
-                        try:
-                            source.commit(destination_id=destination_id)
-                        except Exception as e:
-                            logger.error(f"Error committing source: {e}")
-                            monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
-                            return RunnerStatus(stream=PipelineReturnStatus.ERROR)
+                if os.getenv("ENVIRONMENT") == "production":
+                    try:
+                        source.commit()
+                    except Exception as e:
+                        logger.error(f"Error committing source: {e}")
+                        monitor.track_pipeline_status(PipelineReturnStatus.ERROR)
+                        return RunnerStatus(stream=PipelineReturnStatus.ERROR)
 
                 iteration += 1
 

--- a/bizon/source/source.py
+++ b/bizon/source/source.py
@@ -101,6 +101,6 @@ class AbstractSource(ABC):
         """Return a new session"""
         return Session()
 
-    def commit(self, destination_id: str):
-        """Commit the records to the source for a given destination_id"""
+    def commit(self):
+        """Commit the records to the source"""
         pass


### PR DESCRIPTION
After large scale deployment of per-topic offset commits, we rollback to consumer topic as we noticed performance degradation