### PR TITLE
feat: implement incremental sync for Notion source

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ Runner is the interface used by Bizon to run the pipeline. It can be configured 
 - `process` (asynchronous)
 - `stream` (synchronous)
 
+## Sync Modes
+
+Bizon supports three sync modes:
+- `full_refresh`: Re-syncs all data from scratch on each run
+- `incremental`: Syncs only new/updated data since the last successful run
+- `stream`: Continuous streaming mode for real-time data (e.g., Kafka)
+
+### Incremental Sync
+
+To use incremental sync, set the `sync_mode` and `cursor_field` in your source configuration:
+
+```yaml
+source:
+  name: your_source
+  stream: your_stream
+  sync_mode: incremental
+  cursor_field: updated_at  # The timestamp field to filter records by
+```
+
+**How it works:**
+1. First run: Behaves like full_refresh (fetches all data)
+2. Subsequent runs: Only fetches records where `cursor_field > last_run`
+3. Uses append-only strategy - new records are appended to existing data
+
+**Configuration:**
+- `sync_mode: incremental` - Enable incremental sync
+- `cursor_field` - The timestamp field in your data to filter by (e.g., `updated_at`, `modified_at`, `timestamp`)
+
+**Requirements:**
+- Source must implement `get_records_after()` method
+- Supported destinations: BigQuery (batch), BigQuery Streaming V2
+
 ## Start syncing your data 🚀
 
 ### Quick setup without any dependencies ✌️

--- a/bizon/connectors/destinations/bigquery/config/bigquery_incremental.example.yml
+++ b/bizon/connectors/destinations/bigquery/config/bigquery_incremental.example.yml
@@ -1,0 +1,34 @@
+name: hubspot contacts to bigquery (incremental)
+
+source:
+  name: hubspot
+  stream: contacts
+  sync_mode: incremental
+  cursor_field: updatedAt  # HubSpot's timestamp field for filtering
+  properties:
+    strategy: all
+  authentication:
+    type: api_key
+    api_key: <MY_API_KEY>
+
+destination:
+  # Authentication: If empty it will be infered.
+  # Must have the bigquery.jobUser
+  # Must have the bigquery.dataEditor and storage.objectUser on the supplied dataset and bucket
+  name: bigquery
+  config:
+    buffer_size: 10 # in Mb
+    buffer_flush_timeout: 300 # in seconds
+    dataset_id: bizon_test
+    dataset_location: US
+    project_id: my-gcp-project-id
+    gcs_buffer_bucket: bizon-buffer
+    gcs_buffer_format: parquet
+    # Optional: service_account_key for explicit authentication
+    # service_account_key: >-
+    #   { ... }
+
+# How incremental sync works:
+# 1. First run: Behaves like full_refresh (fetches all data)
+# 2. Subsequent runs: Only fetches records where cursor_field > last_run
+# 3. Uses append-only strategy - new records are appended to existing data

--- a/bizon/connectors/destinations/bigquery/src/destination.py
+++ b/bizon/connectors/destinations/bigquery/src/destination.py
@@ -210,7 +210,11 @@ class BigQueryDestination(AbstractDestination):
             return True
 
         elif self.sync_metadata.sync_mode == SourceSyncModes.INCREMENTAL:
-            # TO DO: Implement incremental sync
+            # Append data from incremental temp table to main table
+            logger.info(f"Appending data from {self.temp_table_id} to {self.table_id} ...")
+            self.bq_client.query(f"INSERT INTO {self.table_id} SELECT * FROM {self.temp_table_id}").result()
+            logger.info(f"Deleting incremental temp table {self.temp_table_id} ...")
+            self.bq_client.delete_table(self.temp_table_id, not_found_ok=True)
             return True
 
         elif self.sync_metadata.sync_mode == SourceSyncModes.STREAM:

--- a/bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py
+++ b/bizon/connectors/destinations/bigquery_streaming_v2/src/destination.py
@@ -39,6 +39,7 @@ from bizon.destination.destination import AbstractDestination
 from bizon.engine.backend.backend import AbstractBackend
 from bizon.monitoring.monitor import AbstractMonitor
 from bizon.source.callback import AbstractSourceCallback
+from bizon.source.config import SourceSyncModes
 
 from .config import BigQueryStreamingV2ConfigDetails
 from .proto_utils import get_proto_schema_and_class
@@ -79,6 +80,17 @@ class BigQueryStreamingV2Destination(AbstractDestination):
     def table_id(self) -> str:
         tabled_id = f"{self.sync_metadata.source_name}_{self.sync_metadata.stream_name}"
         return self.destination_id or f"{self.project_id}.{self.dataset_id}.{tabled_id}"
+
+    @property
+    def temp_table_id(self) -> str:
+        if self.sync_metadata.sync_mode == SourceSyncModes.FULL_REFRESH:
+            return f"{self.table_id}_temp"
+        elif self.sync_metadata.sync_mode == SourceSyncModes.INCREMENTAL:
+            return f"{self.table_id}_incremental"
+        elif self.sync_metadata.sync_mode == SourceSyncModes.STREAM:
+            return f"{self.table_id}"
+        # Default fallback
+        return f"{self.table_id}"
 
     def get_bigquery_schema(self) -> List[bigquery.SchemaField]:
         if self.config.unnest:
@@ -232,14 +244,14 @@ class BigQueryStreamingV2Destination(AbstractDestination):
                     deserialized_row = self.from_protobuf_serialization(table_row_class, serialized_row)
                     deserialized_rows.append(deserialized_row)
 
-                # For large rows, we need to use the main client
+                # For large rows, we need to use the main client (write to temp_table_id)
                 job_config = bigquery.LoadJobConfig(
                     source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
-                    schema=self.bq_client.get_table(self.table_id).schema,
+                    schema=self.bq_client.get_table(self.temp_table_id).schema,
                     ignore_unknown_values=True,
                 )
                 load_job = self.bq_client.load_table_from_json(
-                    deserialized_rows, self.table_id, job_config=job_config, timeout=300
+                    deserialized_rows, self.temp_table_id, job_config=job_config, timeout=300
                 )
                 result = load_job.result()
                 if load_job.state != "DONE":
@@ -261,9 +273,9 @@ class BigQueryStreamingV2Destination(AbstractDestination):
             raise
 
     def load_to_bigquery_via_streaming(self, df_destination_records: pl.DataFrame) -> str:
-        # Create table if it does not exist
+        # Create table if it does not exist (use temp_table_id for staging)
         schema = self.get_bigquery_schema()
-        table = bigquery.Table(self.table_id, schema=schema)
+        table = bigquery.Table(self.temp_table_id, schema=schema)
         time_partitioning = TimePartitioning(
             field=self.config.time_partitioning.field, type_=self.config.time_partitioning.type
         )
@@ -274,7 +286,7 @@ class BigQueryStreamingV2Destination(AbstractDestination):
         try:
             table = self.bq_client.create_table(table)
         except Conflict:
-            table = self.bq_client.get_table(self.table_id)
+            table = self.bq_client.get_table(self.temp_table_id)
             # Compare and update schema if needed
             existing_fields = {field.name: field for field in table.schema}
             new_fields = {field.name: field for field in self.get_bigquery_schema()}
@@ -288,12 +300,13 @@ class BigQueryStreamingV2Destination(AbstractDestination):
                 table.schema = updated_schema
                 table = self.bq_client.update_table(table, ["schema"])
 
-        # Create the stream
-        if self.destination_id:
-            project, dataset, table_name = self.destination_id.split(".")
+        # Create the stream (use temp_table_id for staging)
+        temp_table_parts = self.temp_table_id.split(".")
+        if len(temp_table_parts) == 3:
+            project, dataset, table_name = temp_table_parts
             parent = BigQueryWriteClient.table_path(project, dataset, table_name)
         else:
-            parent = BigQueryWriteClient.table_path(self.project_id, self.dataset_id, self.destination_id)
+            parent = BigQueryWriteClient.table_path(self.project_id, self.dataset_id, temp_table_parts[-1])
 
         stream_name = f"{parent}/_default"
 
@@ -409,3 +422,29 @@ class BigQueryStreamingV2Destination(AbstractDestination):
             if large_rows:
                 logger.warning(f"Yielding large rows batch of {len(large_rows)} rows")
             yield {"stream_batch": current_batch, "json_batch": large_rows}
+
+    def finalize(self):
+        """Finalize the sync by moving data from temp table to main table based on sync mode."""
+        if self.sync_metadata.sync_mode == SourceSyncModes.FULL_REFRESH:
+            # Replace main table with temp table data
+            logger.info(f"Loading temp table {self.temp_table_id} data into {self.table_id} ...")
+            self.bq_client.query(
+                f"CREATE OR REPLACE TABLE {self.table_id} AS SELECT * FROM {self.temp_table_id}"
+            ).result()
+            logger.info(f"Deleting temp table {self.temp_table_id} ...")
+            self.bq_client.delete_table(self.temp_table_id, not_found_ok=True)
+            return True
+
+        elif self.sync_metadata.sync_mode == SourceSyncModes.INCREMENTAL:
+            # Append data from incremental temp table to main table
+            logger.info(f"Appending data from {self.temp_table_id} to {self.table_id} ...")
+            self.bq_client.query(f"INSERT INTO {self.table_id} SELECT * FROM {self.temp_table_id}").result()
+            logger.info(f"Deleting incremental temp table {self.temp_table_id} ...")
+            self.bq_client.delete_table(self.temp_table_id, not_found_ok=True)
+            return True
+
+        elif self.sync_metadata.sync_mode == SourceSyncModes.STREAM:
+            # Direct writes, no finalization needed
+            return True
+
+        return True

--- a/bizon/connectors/destinations/file/config/file_incremental.example.yml
+++ b/bizon/connectors/destinations/file/config/file_incremental.example.yml
@@ -1,0 +1,22 @@
+name: dummy to file (incremental)
+
+source:
+  name: dummy
+  stream: creatures
+  sync_mode: incremental
+  cursor_field: updated_at  # Field to filter records by timestamp
+  authentication:
+    type: api_key
+    params:
+      token: dummy_key
+
+destination:
+  name: file
+  config:
+    format: json
+
+# How incremental sync works with file destination:
+# 1. First run: Behaves like full_refresh (creates new file)
+# 2. Subsequent runs: Only fetches records where cursor_field > last_run
+# 3. New records are appended to the existing JSON file
+# 4. Writes to temp file (_incremental.json) then appends to main file on finalize

--- a/bizon/connectors/destinations/file/src/destination.py
+++ b/bizon/connectors/destinations/file/src/destination.py
@@ -1,13 +1,17 @@
+import os
+import shutil
 from typing import Tuple
 
 import orjson
 import polars as pl
+from loguru import logger
 
 from bizon.common.models import SyncMetadata
 from bizon.destination.destination import AbstractDestination
 from bizon.engine.backend.backend import AbstractBackend
 from bizon.monitoring.monitor import AbstractMonitor
 from bizon.source.callback import AbstractSourceCallback
+from bizon.source.config import SourceSyncModes
 
 from .config import FileDestinationDetailsConfig
 
@@ -24,6 +28,30 @@ class FileDestination(AbstractDestination):
         super().__init__(sync_metadata, config, backend, source_callback, monitor)
         self.config: FileDestinationDetailsConfig = config
 
+    @property
+    def file_path(self) -> str:
+        """Main output file path."""
+        return f"{self.destination_id}.json"
+
+    @property
+    def temp_file_path(self) -> str:
+        """Temp file path for FULL_REFRESH mode."""
+        if self.sync_metadata.sync_mode == SourceSyncModes.FULL_REFRESH.value:
+            return f"{self.destination_id}_temp.json"
+        elif self.sync_metadata.sync_mode == SourceSyncModes.INCREMENTAL.value:
+            return f"{self.destination_id}_incremental.json"
+        return self.file_path
+
+    @property
+    def write_path(self) -> str:
+        """Get the path to write to based on sync mode."""
+        if self.sync_metadata.sync_mode in [
+            SourceSyncModes.FULL_REFRESH.value,
+            SourceSyncModes.INCREMENTAL.value,
+        ]:
+            return self.temp_file_path
+        return self.file_path
+
     def check_connection(self) -> bool:
         return True
 
@@ -34,7 +62,7 @@ class FileDestination(AbstractDestination):
         if self.config.unnest:
             schema_keys = set([column.name for column in self.record_schemas[self.destination_id]])
 
-            with open(f"{self.destination_id}.json", "a") as f:
+            with open(self.write_path, "a") as f:
                 for value in [orjson.loads(data) for data in df_destination_records["source_data"].to_list()]:
                     assert set(value.keys()) == schema_keys, "Keys do not match the schema"
 
@@ -46,6 +74,35 @@ class FileDestination(AbstractDestination):
                     f.write(f"{orjson.dumps(row).decode('utf-8')}\n")
 
         else:
-            df_destination_records.write_ndjson(f"{self.destination_id}.json")
+            # Append mode for incremental, overwrite for full refresh on first write
+            with open(self.write_path, "a") as f:
+                for record in df_destination_records.iter_rows(named=True):
+                    f.write(f"{orjson.dumps(record).decode('utf-8')}\n")
 
         return True, ""
+
+    def finalize(self) -> bool:
+        """Finalize the sync by moving temp file to main file based on sync mode."""
+        if self.sync_metadata.sync_mode == SourceSyncModes.FULL_REFRESH.value:
+            # Replace main file with temp file
+            if os.path.exists(self.temp_file_path):
+                logger.info(f"File destination: Moving {self.temp_file_path} to {self.file_path}")
+                shutil.move(self.temp_file_path, self.file_path)
+            return True
+
+        elif self.sync_metadata.sync_mode == SourceSyncModes.INCREMENTAL.value:
+            # Append temp file contents to main file
+            if os.path.exists(self.temp_file_path):
+                logger.info(f"File destination: Appending {self.temp_file_path} to {self.file_path}")
+                with open(self.file_path, "a") as main_file:
+                    with open(self.temp_file_path) as temp_file:
+                        main_file.write(temp_file.read())
+                os.remove(self.temp_file_path)
+            return True
+
+        elif self.sync_metadata.sync_mode == SourceSyncModes.STREAM.value:
+            # Direct writes, no finalization needed
+            logger.info("File destination: STREAM sync batch completed")
+            return True
+
+        return True

--- a/bizon/connectors/destinations/logger/config/logger_incremental.example.yml
+++ b/bizon/connectors/destinations/logger/config/logger_incremental.example.yml
@@ -1,0 +1,21 @@
+name: dummy to logger (incremental)
+
+source:
+  name: dummy
+  stream: creatures
+  sync_mode: incremental
+  cursor_field: updated_at  # Field to filter records by timestamp
+  authentication:
+    type: api_key
+    params:
+      token: dummy_key
+
+destination:
+  name: logger
+  config:
+    dummy: dummy
+
+# How incremental sync works:
+# 1. First run: Behaves like full_refresh (fetches all data)
+# 2. Subsequent runs: Only fetches records where cursor_field > last_run
+# 3. Logger outputs records with [incremental] prefix for easy identification

--- a/bizon/connectors/sources/gsheets/config/service_account_incremental.example.yml
+++ b/bizon/connectors/sources/gsheets/config/service_account_incremental.example.yml
@@ -1,0 +1,51 @@
+name: gsheets incremental sync
+
+source:
+  name: gsheets
+  stream: worksheet
+  sync_mode: incremental
+  cursor_field: updated_at  # Column name in your sheet containing timestamps
+  spreadsheet_url: <MY_SPREADSHEET_URL>
+  worksheet_name: Sheet1
+  service_account_key: >-
+    {
+      "type": "service_account",
+      "project_id": "<MY_GCP_PROJECT>",
+      "private_key_id": "xxx",
+      "private_key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+      "client_email": "bizon@<MY_GCP_PROJECT>.iam.gserviceaccount.com",
+      "client_id": "999999999999",
+      "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/...",
+      "universe_domain": "googleapis.com"
+    }
+
+destination:
+  name: bigquery
+  config:
+    project_id: <MY_GCP_PROJECT>
+    dataset_id: gsheets_data
+    dataset_location: US
+    gcs_buffer_bucket: <MY_GCS_BUCKET>
+    gcs_buffer_format: parquet
+
+engine:
+  backend:
+    type: bigquery
+    database: <MY_GCP_PROJECT>
+    schema: bizon_backend
+    syncCursorInDBEvery: 2
+
+# Incremental sync for Google Sheets:
+# - First run: Fetches all rows (full refresh behavior)
+# - Subsequent runs: Only fetches rows where cursor_field > last_run
+#
+# IMPORTANT: Your Google Sheet must have a timestamp column for incremental sync.
+# Common patterns:
+# - Add an "updated_at" column with formula: =NOW() (updates on edit)
+# - Use Google Apps Script to auto-update timestamps on row changes
+# - Manually maintain a "last_modified" column
+#
+# If your sheet doesn't have timestamps, use sync_mode: full_refresh instead.

--- a/bizon/connectors/sources/hubspot/config/api_key_incremental.example.yml
+++ b/bizon/connectors/sources/hubspot/config/api_key_incremental.example.yml
@@ -1,0 +1,40 @@
+name: hubspot contacts incremental sync
+
+source:
+  name: hubspot
+  stream: contacts
+  sync_mode: incremental
+  cursor_field: updatedAt  # HubSpot's timestamp field for contacts
+  properties:
+    strategy: all
+  authentication:
+    type: api_key
+    params:
+      token: <MY_API_KEY>
+
+destination:
+  name: bigquery
+  config:
+    project_id: <MY_GCP_PROJECT>
+    dataset_id: hubspot_data
+    dataset_location: US
+    gcs_buffer_bucket: <MY_GCS_BUCKET>
+    gcs_buffer_format: parquet
+
+engine:
+  backend:
+    type: bigquery
+    database: <MY_GCP_PROJECT>
+    schema: bizon_backend
+    syncCursorInDBEvery: 2
+
+# Incremental sync for HubSpot:
+# - First run: Fetches all contacts (full refresh behavior)
+# - Subsequent runs: Only fetches contacts where updatedAt > last_run
+#
+# Common cursor fields by stream:
+# - contacts: updatedAt
+# - companies: updatedAt
+# - deals: updatedAt
+# - tickets: updatedAt
+# - products: updatedAt

--- a/bizon/connectors/sources/notion/config/api_key_incremental.example.yml
+++ b/bizon/connectors/sources/notion/config/api_key_incremental.example.yml
@@ -1,0 +1,48 @@
+name: notion pages incremental sync
+
+source:
+  name: notion
+  stream: pages  # Options: databases, data_sources, pages, blocks, users
+  sync_mode: incremental
+  cursor_field: last_edited_time  # Notion's timestamp field
+  authentication:
+    type: api_key
+    params:
+      token: secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  # Your Notion integration token
+
+  # List of database IDs to fetch data from
+  database_ids:
+    - "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+  # Number of results per API call (1-100, default: 100)
+  page_size: 100
+
+destination:
+  name: bigquery
+  config:
+    project_id: <MY_GCP_PROJECT>
+    dataset_id: notion_data
+    dataset_location: US
+    gcs_buffer_bucket: <MY_GCS_BUCKET>
+    gcs_buffer_format: parquet
+
+engine:
+  backend:
+    type: bigquery
+    database: <MY_GCP_PROJECT>
+    schema: bizon_backend
+    syncCursorInDBEvery: 2
+
+# Incremental sync for Notion:
+# - First run: Fetches all pages/databases (full refresh behavior)
+# - Subsequent runs: Only fetches items where last_edited_time > last_run
+#
+# Supported streams for incremental sync:
+# - pages, all_pages: Uses Search API with last_edited_time filter
+# - databases, all_databases: Uses Search API to find updated data_sources
+# - blocks: First finds updated pages, then fetches their blocks
+# - blocks_markdown, all_blocks_markdown: Same as blocks, converts to markdown
+#
+# Not supported (falls back to full refresh):
+# - users: No timestamp filter available
+# - data_sources: Use databases stream instead

--- a/bizon/source/config.py
+++ b/bizon/source/config.py
@@ -42,6 +42,12 @@ class SourceConfig(BaseModel, ABC):
         default=SourceSyncModes.FULL_REFRESH,
     )
 
+    cursor_field: Optional[str] = Field(
+        default=None,
+        description="Field name to use for incremental filtering (e.g., 'updated_at', 'modified_at'). "
+        "Source will fetch records where this field > last_run timestamp.",
+    )
+
     force_ignore_checkpoint: bool = Field(
         description="Whether to force recreate the sync from iteration 0. Existing checkpoints will be ignored.",
         default=False,

--- a/bizon/source/models.py
+++ b/bizon/source/models.py
@@ -44,4 +44,5 @@ class SourceIteration(BaseModel):
 
 class SourceIncrementalState(BaseModel):
     last_run: datetime = Field(..., description="Timestamp of the last successful run")
-    state: dict = Field(..., description="Incremental state information from the latest sync")
+    state: dict = Field(default_factory=dict, description="Incremental state information from the latest sync")
+    cursor_field: Optional[str] = Field(default=None, description="The field name to filter records by timestamp")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bizon"
-version = "0.1.2"
+version = "0.2.0"
 description = "Extract and load your data reliably from API Clients with native fault-tolerant and checkpointing mechanism."
 authors = [
     { name = "Antoine Balliet", email = "antoine.balliet@gmail.com" },

--- a/tests/connectors/destinations/bigquery/test_bigquery_incremental.py
+++ b/tests/connectors/destinations/bigquery/test_bigquery_incremental.py
@@ -1,0 +1,181 @@
+"""Tests for BigQuery destination incremental sync mode."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bizon.common.models import SyncMetadata
+from bizon.connectors.destinations.bigquery.src.config import (
+    BigQueryConfigDetails,
+    GCSBufferFormat,
+)
+from bizon.connectors.destinations.bigquery.src.destination import BigQueryDestination
+from bizon.source.config import SourceSyncModes
+
+
+@pytest.fixture
+def mock_bq_client():
+    """Mock BigQuery client."""
+    with patch("bizon.connectors.destinations.bigquery.src.destination.bigquery.Client") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_gcs_client():
+    """Mock GCS client."""
+    with patch("bizon.connectors.destinations.bigquery.src.destination.storage.Client") as mock:
+        yield mock
+
+
+@pytest.fixture
+def bigquery_config():
+    """Create a BigQuery config for testing."""
+    return BigQueryConfigDetails(
+        project_id="test-project",
+        dataset_id="test_dataset",
+        gcs_buffer_bucket="test-bucket",
+        gcs_buffer_format=GCSBufferFormat.PARQUET,
+    )
+
+
+def create_sync_metadata(sync_mode: SourceSyncModes) -> SyncMetadata:
+    """Create SyncMetadata with specified sync mode."""
+    return SyncMetadata(
+        name="test_pipeline",
+        job_id="test_job_123",
+        source_name="test_source",
+        stream_name="test_stream",
+        destination_name="bigquery",
+        destination_alias="bigquery",
+        sync_mode=sync_mode.value,
+    )
+
+
+class TestBigQueryTempTableId:
+    """Test cases for temp_table_id property."""
+
+    def test_temp_table_id_full_refresh(self, bigquery_config, mock_bq_client, mock_gcs_client):
+        """Test that temp_table_id returns _temp suffix for FULL_REFRESH mode."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.FULL_REFRESH)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        expected_table_id = f"{destination.table_id}_temp"
+        assert destination.temp_table_id == expected_table_id
+        assert destination.temp_table_id.endswith("_temp")
+
+    def test_temp_table_id_incremental(self, bigquery_config, mock_bq_client, mock_gcs_client):
+        """Test that temp_table_id returns _incremental suffix for INCREMENTAL mode."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        expected_table_id = f"{destination.table_id}_incremental"
+        assert destination.temp_table_id == expected_table_id
+        assert destination.temp_table_id.endswith("_incremental")
+
+    def test_temp_table_id_stream(self, bigquery_config, mock_bq_client, mock_gcs_client):
+        """Test that temp_table_id returns main table_id for STREAM mode (no temp table)."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.STREAM)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # STREAM mode writes directly to main table
+        assert destination.temp_table_id == destination.table_id
+        assert not destination.temp_table_id.endswith("_temp")
+        assert not destination.temp_table_id.endswith("_incremental")
+
+
+class TestBigQueryFinalize:
+    """Test cases for finalize() method."""
+
+    def test_finalize_full_refresh(self, bigquery_config, mock_bq_client, mock_gcs_client):
+        """Test finalize() for FULL_REFRESH mode creates/replaces table."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.FULL_REFRESH)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # Mock the query method
+        mock_query = MagicMock()
+        destination.bq_client.query = mock_query
+        destination.bq_client.delete_table = MagicMock()
+
+        result = destination.finalize()
+
+        assert result is True
+        # Check that CREATE OR REPLACE was called
+        mock_query.assert_called_once()
+        query_call = mock_query.call_args[0][0]
+        assert "CREATE OR REPLACE TABLE" in query_call
+
+    def test_finalize_incremental(self, bigquery_config, mock_bq_client, mock_gcs_client):
+        """Test finalize() for INCREMENTAL mode appends data."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # Mock the query method
+        mock_query = MagicMock()
+        mock_query.return_value.result = MagicMock()
+        destination.bq_client.query = mock_query
+        destination.bq_client.delete_table = MagicMock()
+
+        result = destination.finalize()
+
+        assert result is True
+        # Check that INSERT INTO was called
+        mock_query.assert_called_once()
+        query_call = mock_query.call_args[0][0]
+        assert "INSERT INTO" in query_call
+
+    def test_finalize_stream(self, bigquery_config, mock_bq_client, mock_gcs_client):
+        """Test finalize() for STREAM mode does nothing."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.STREAM)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # Mock the query method
+        mock_query = MagicMock()
+        destination.bq_client.query = mock_query
+
+        result = destination.finalize()
+
+        assert result is True
+        # STREAM mode should not call query
+        mock_query.assert_not_called()

--- a/tests/connectors/destinations/bigquery/test_bigquery_incremental_live.py
+++ b/tests/connectors/destinations/bigquery/test_bigquery_incremental_live.py
@@ -1,0 +1,241 @@
+"""Live integration tests for BigQuery destination incremental sync mode.
+
+These tests hit real BigQuery APIs and require valid GCP credentials.
+Run with: uv run pytest tests/connectors/destinations/bigquery/test_bigquery_incremental_live.py -v
+"""
+
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud import bigquery
+from google.cloud.exceptions import NotFound
+from pytz import UTC
+
+from bizon.common.models import SyncMetadata
+from bizon.connectors.destinations.bigquery.src.config import (
+    BigQueryConfigDetails,
+    GCSBufferFormat,
+)
+from bizon.connectors.destinations.bigquery.src.destination import BigQueryDestination
+from bizon.source.config import SourceSyncModes
+
+# Test configuration - update these values for your GCP project
+PROJECT_ID = "my-gcp-project"
+DATASET_ID = "bizon_test"
+GCS_BUCKET = "my-gcs-buffer-bucket"
+
+
+@pytest.fixture
+def test_run_id():
+    """Generate unique ID for this test run to avoid conflicts."""
+    return str(uuid.uuid4())[:8]
+
+
+@pytest.fixture
+def bigquery_config():
+    """Create a BigQuery config for live testing."""
+    return BigQueryConfigDetails(
+        project_id=PROJECT_ID,
+        dataset_id=DATASET_ID,
+        gcs_buffer_bucket=GCS_BUCKET,
+        gcs_buffer_format=GCSBufferFormat.PARQUET,
+    )
+
+
+@pytest.fixture
+def bq_client():
+    """Create a real BigQuery client."""
+    return bigquery.Client(project=PROJECT_ID)
+
+
+def create_sync_metadata(sync_mode: SourceSyncModes, test_run_id: str) -> SyncMetadata:
+    """Create SyncMetadata with specified sync mode."""
+    return SyncMetadata(
+        name="test_pipeline",
+        job_id=f"test_job_{test_run_id}",
+        source_name="test_source",
+        stream_name=f"test_stream_{test_run_id}",
+        destination_name="bigquery",
+        destination_alias="bigquery",
+        sync_mode=sync_mode.value,
+    )
+
+
+def cleanup_tables(bq_client: bigquery.Client, table_ids: list[str]):
+    """Clean up test tables."""
+    for table_id in table_ids:
+        try:
+            bq_client.delete_table(table_id, not_found_ok=True)
+        except Exception as e:
+            print(f"Warning: Could not delete table {table_id}: {e}")
+
+
+class TestBigQueryIncrementalLive:
+    """Live integration tests for incremental sync."""
+
+    def test_temp_table_id_incremental_live(self, bigquery_config, test_run_id):
+        """Test temp_table_id property with real destination."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL, test_run_id)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        assert destination.temp_table_id.endswith("_incremental")
+        assert PROJECT_ID in destination.temp_table_id
+        assert DATASET_ID in destination.temp_table_id
+
+    def test_finalize_incremental_live(self, bigquery_config, bq_client, test_run_id):
+        """Test finalize() for INCREMENTAL mode with real BigQuery tables."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL, test_run_id)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        main_table_id = destination.table_id
+        temp_table_id = destination.temp_table_id
+
+        try:
+            # Create schema
+            schema = [
+                bigquery.SchemaField("_source_record_id", "STRING", mode="REQUIRED"),
+                bigquery.SchemaField("_source_timestamp", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_source_data", "STRING", mode="NULLABLE"),
+                bigquery.SchemaField("_bizon_extracted_at", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_bizon_loaded_at", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_bizon_id", "STRING", mode="REQUIRED"),
+            ]
+
+            # Create main table with initial data
+            main_table = bigquery.Table(main_table_id, schema=schema)
+            bq_client.create_table(main_table, exists_ok=True)
+
+            # Insert initial row into main table
+            initial_rows = [
+                {
+                    "_source_record_id": "initial_1",
+                    "_source_timestamp": datetime.now(tz=UTC).isoformat(),
+                    "_source_data": '{"key": "initial"}',
+                    "_bizon_extracted_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_loaded_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_id": "bizon_initial_1",
+                }
+            ]
+            bq_client.insert_rows_json(main_table_id, initial_rows)
+
+            # Create temp incremental table with new data
+            temp_table = bigquery.Table(temp_table_id, schema=schema)
+            bq_client.create_table(temp_table, exists_ok=True)
+
+            # Insert incremental row into temp table
+            incremental_rows = [
+                {
+                    "_source_record_id": "incremental_1",
+                    "_source_timestamp": datetime.now(tz=UTC).isoformat(),
+                    "_source_data": '{"key": "incremental"}',
+                    "_bizon_extracted_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_loaded_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_id": "bizon_incremental_1",
+                }
+            ]
+            bq_client.insert_rows_json(temp_table_id, incremental_rows)
+
+            # Wait for streaming buffer to be available
+            import time
+
+            time.sleep(2)
+
+            # Run finalize
+            result = destination.finalize()
+
+            assert result is True
+
+            # Verify temp table was deleted
+            with pytest.raises(NotFound):
+                bq_client.get_table(temp_table_id)
+
+            # Verify main table has both rows (initial + incremental)
+            query = f"SELECT COUNT(*) as count FROM `{main_table_id}`"
+            query_job = bq_client.query(query)
+            results = list(query_job.result())
+            assert results[0].count == 2
+
+        finally:
+            cleanup_tables(bq_client, [main_table_id, temp_table_id])
+
+    def test_finalize_full_refresh_live(self, bigquery_config, bq_client, test_run_id):
+        """Test finalize() for FULL_REFRESH mode with real BigQuery tables."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.FULL_REFRESH, test_run_id)
+
+        destination = BigQueryDestination(
+            sync_metadata=sync_metadata,
+            config=bigquery_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        main_table_id = destination.table_id
+        temp_table_id = destination.temp_table_id
+
+        try:
+            # Create schema
+            schema = [
+                bigquery.SchemaField("_source_record_id", "STRING", mode="REQUIRED"),
+                bigquery.SchemaField("_source_timestamp", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_source_data", "STRING", mode="NULLABLE"),
+                bigquery.SchemaField("_bizon_extracted_at", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_bizon_loaded_at", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_bizon_id", "STRING", mode="REQUIRED"),
+            ]
+
+            # Create temp table with fresh data
+            temp_table = bigquery.Table(temp_table_id, schema=schema)
+            bq_client.create_table(temp_table, exists_ok=True)
+
+            # Insert row into temp table
+            rows = [
+                {
+                    "_source_record_id": "fresh_1",
+                    "_source_timestamp": datetime.now(tz=UTC).isoformat(),
+                    "_source_data": '{"key": "fresh"}',
+                    "_bizon_extracted_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_loaded_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_id": "bizon_fresh_1",
+                }
+            ]
+            bq_client.insert_rows_json(temp_table_id, rows)
+
+            # Wait for streaming buffer
+            import time
+
+            time.sleep(2)
+
+            # Run finalize
+            result = destination.finalize()
+
+            assert result is True
+
+            # Verify temp table was deleted
+            with pytest.raises(NotFound):
+                bq_client.get_table(temp_table_id)
+
+            # Verify main table exists with data
+            query = f"SELECT COUNT(*) as count FROM `{main_table_id}`"
+            query_job = bq_client.query(query)
+            results = list(query_job.result())
+            assert results[0].count == 1
+
+        finally:
+            cleanup_tables(bq_client, [main_table_id, temp_table_id])

--- a/tests/connectors/destinations/bigquery_streaming_v2/test_bigquery_streaming_v2_incremental.py
+++ b/tests/connectors/destinations/bigquery_streaming_v2/test_bigquery_streaming_v2_incremental.py
@@ -1,0 +1,174 @@
+"""Tests for BigQuery Streaming V2 destination incremental sync mode."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bizon.common.models import SyncMetadata
+from bizon.connectors.destinations.bigquery_streaming_v2.src.config import (
+    BigQueryStreamingV2ConfigDetails,
+)
+from bizon.connectors.destinations.bigquery_streaming_v2.src.destination import (
+    BigQueryStreamingV2Destination,
+)
+from bizon.source.config import SourceSyncModes
+
+
+@pytest.fixture
+def mock_bq_client():
+    """Mock BigQuery client."""
+    with patch("bizon.connectors.destinations.bigquery_streaming_v2.src.destination.bigquery.Client") as mock:
+        yield mock
+
+
+@pytest.fixture
+def streaming_v2_config():
+    """Create a BigQuery Streaming V2 config for testing."""
+    return BigQueryStreamingV2ConfigDetails(
+        project_id="test-project",
+        dataset_id="test_dataset",
+    )
+
+
+def create_sync_metadata(sync_mode: SourceSyncModes) -> SyncMetadata:
+    """Create SyncMetadata with specified sync mode."""
+    return SyncMetadata(
+        name="test_pipeline",
+        job_id="test_job_123",
+        source_name="test_source",
+        stream_name="test_stream",
+        destination_name="bigquery_streaming_v2",
+        destination_alias="bigquery",
+        sync_mode=sync_mode.value,
+    )
+
+
+class TestBigQueryStreamingV2TempTableId:
+    """Test cases for temp_table_id property."""
+
+    def test_temp_table_id_full_refresh(self, streaming_v2_config, mock_bq_client):
+        """Test that temp_table_id returns _temp suffix for FULL_REFRESH mode."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.FULL_REFRESH)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        expected_table_id = f"{destination.table_id}_temp"
+        assert destination.temp_table_id == expected_table_id
+        assert destination.temp_table_id.endswith("_temp")
+
+    def test_temp_table_id_incremental(self, streaming_v2_config, mock_bq_client):
+        """Test that temp_table_id returns _incremental suffix for INCREMENTAL mode."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        expected_table_id = f"{destination.table_id}_incremental"
+        assert destination.temp_table_id == expected_table_id
+        assert destination.temp_table_id.endswith("_incremental")
+
+    def test_temp_table_id_stream(self, streaming_v2_config, mock_bq_client):
+        """Test that temp_table_id returns main table_id for STREAM mode (no temp table)."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.STREAM)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # STREAM mode writes directly to main table
+        assert destination.temp_table_id == destination.table_id
+        assert not destination.temp_table_id.endswith("_temp")
+        assert not destination.temp_table_id.endswith("_incremental")
+
+
+class TestBigQueryStreamingV2Finalize:
+    """Test cases for finalize() method."""
+
+    def test_finalize_full_refresh(self, streaming_v2_config, mock_bq_client):
+        """Test finalize() for FULL_REFRESH mode creates/replaces table."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.FULL_REFRESH)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # Mock the query method
+        mock_query = MagicMock()
+        mock_query.return_value.result = MagicMock()
+        destination.bq_client.query = mock_query
+        destination.bq_client.delete_table = MagicMock()
+
+        result = destination.finalize()
+
+        assert result is True
+        # Check that CREATE OR REPLACE was called
+        mock_query.assert_called_once()
+        query_call = mock_query.call_args[0][0]
+        assert "CREATE OR REPLACE TABLE" in query_call
+
+    def test_finalize_incremental(self, streaming_v2_config, mock_bq_client):
+        """Test finalize() for INCREMENTAL mode appends data."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # Mock the query method
+        mock_query = MagicMock()
+        mock_query.return_value.result = MagicMock()
+        destination.bq_client.query = mock_query
+        destination.bq_client.delete_table = MagicMock()
+
+        result = destination.finalize()
+
+        assert result is True
+        # Check that INSERT INTO was called
+        mock_query.assert_called_once()
+        query_call = mock_query.call_args[0][0]
+        assert "INSERT INTO" in query_call
+
+    def test_finalize_stream(self, streaming_v2_config, mock_bq_client):
+        """Test finalize() for STREAM mode does nothing."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.STREAM)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        # Mock the query method
+        mock_query = MagicMock()
+        destination.bq_client.query = mock_query
+
+        result = destination.finalize()
+
+        assert result is True
+        # STREAM mode should not call query
+        mock_query.assert_not_called()

--- a/tests/connectors/destinations/bigquery_streaming_v2/test_bigquery_streaming_v2_incremental_live.py
+++ b/tests/connectors/destinations/bigquery_streaming_v2/test_bigquery_streaming_v2_incremental_live.py
@@ -1,0 +1,240 @@
+"""Live integration tests for BigQuery Streaming V2 destination incremental sync mode.
+
+These tests hit real BigQuery APIs and require valid GCP credentials.
+Run with: uv run pytest tests/connectors/destinations/bigquery_streaming_v2/test_bigquery_streaming_v2_incremental_live.py -v
+"""
+
+import time
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from google.api_core.exceptions import NotFound
+from google.cloud import bigquery
+from pytz import UTC
+
+from bizon.common.models import SyncMetadata
+from bizon.connectors.destinations.bigquery_streaming_v2.src.config import (
+    BigQueryStreamingV2ConfigDetails,
+)
+from bizon.connectors.destinations.bigquery_streaming_v2.src.destination import (
+    BigQueryStreamingV2Destination,
+)
+from bizon.source.config import SourceSyncModes
+
+# Test configuration - update these values for your GCP project
+PROJECT_ID = "my-gcp-project"
+DATASET_ID = "bizon_test"
+
+
+@pytest.fixture
+def test_run_id():
+    """Generate unique ID for this test run to avoid conflicts."""
+    return str(uuid.uuid4())[:8]
+
+
+@pytest.fixture
+def streaming_v2_config():
+    """Create a BigQuery Streaming V2 config for live testing."""
+    return BigQueryStreamingV2ConfigDetails(
+        project_id=PROJECT_ID,
+        dataset_id=DATASET_ID,
+    )
+
+
+@pytest.fixture
+def bq_client():
+    """Create a real BigQuery client."""
+    return bigquery.Client(project=PROJECT_ID)
+
+
+def create_sync_metadata(sync_mode: SourceSyncModes, test_run_id: str) -> SyncMetadata:
+    """Create SyncMetadata with specified sync mode."""
+    return SyncMetadata(
+        name="test_pipeline",
+        job_id=f"test_job_{test_run_id}",
+        source_name="test_source",
+        stream_name=f"test_stream_v2_{test_run_id}",
+        destination_name="bigquery_streaming_v2",
+        destination_alias="bigquery",
+        sync_mode=sync_mode.value,
+    )
+
+
+def cleanup_tables(bq_client: bigquery.Client, table_ids: list[str]):
+    """Clean up test tables."""
+    for table_id in table_ids:
+        try:
+            bq_client.delete_table(table_id, not_found_ok=True)
+        except Exception as e:
+            print(f"Warning: Could not delete table {table_id}: {e}")
+
+
+class TestBigQueryStreamingV2IncrementalLive:
+    """Live integration tests for Streaming V2 incremental sync."""
+
+    def test_temp_table_id_incremental_live(self, streaming_v2_config, test_run_id):
+        """Test temp_table_id property with real destination."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL, test_run_id)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        assert destination.temp_table_id.endswith("_incremental")
+        assert PROJECT_ID in destination.temp_table_id
+        assert DATASET_ID in destination.temp_table_id
+
+    def test_finalize_incremental_live(self, streaming_v2_config, bq_client, test_run_id):
+        """Test finalize() for INCREMENTAL mode with real BigQuery tables."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.INCREMENTAL, test_run_id)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        main_table_id = destination.table_id
+        temp_table_id = destination.temp_table_id
+
+        try:
+            # Create schema
+            schema = [
+                bigquery.SchemaField("_source_record_id", "STRING", mode="REQUIRED"),
+                bigquery.SchemaField("_source_timestamp", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_source_data", "JSON", mode="NULLABLE"),
+                bigquery.SchemaField("_bizon_extracted_at", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField(
+                    "_bizon_loaded_at", "TIMESTAMP", mode="REQUIRED", default_value_expression="CURRENT_TIMESTAMP()"
+                ),
+                bigquery.SchemaField("_bizon_id", "STRING", mode="REQUIRED"),
+            ]
+
+            # Create main table with initial data
+            main_table = bigquery.Table(main_table_id, schema=schema)
+            bq_client.create_table(main_table, exists_ok=True)
+
+            # Insert initial row into main table
+            initial_rows = [
+                {
+                    "_source_record_id": "initial_1",
+                    "_source_timestamp": datetime.now(tz=UTC).isoformat(),
+                    "_source_data": '{"key": "initial"}',
+                    "_bizon_extracted_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_loaded_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_id": "bizon_initial_1",
+                }
+            ]
+            bq_client.insert_rows_json(main_table_id, initial_rows)
+
+            # Create temp incremental table with new data
+            temp_table = bigquery.Table(temp_table_id, schema=schema)
+            bq_client.create_table(temp_table, exists_ok=True)
+
+            # Insert incremental row into temp table
+            incremental_rows = [
+                {
+                    "_source_record_id": "incremental_1",
+                    "_source_timestamp": datetime.now(tz=UTC).isoformat(),
+                    "_source_data": '{"key": "incremental"}',
+                    "_bizon_extracted_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_loaded_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_id": "bizon_incremental_1",
+                }
+            ]
+            bq_client.insert_rows_json(temp_table_id, incremental_rows)
+
+            # Wait for streaming buffer to be available
+            time.sleep(2)
+
+            # Run finalize
+            result = destination.finalize()
+
+            assert result is True
+
+            # Verify temp table was deleted
+            with pytest.raises(NotFound):
+                bq_client.get_table(temp_table_id)
+
+            # Verify main table has both rows (initial + incremental)
+            query = f"SELECT COUNT(*) as count FROM `{main_table_id}`"
+            query_job = bq_client.query(query)
+            results = list(query_job.result())
+            assert results[0].count == 2
+
+        finally:
+            cleanup_tables(bq_client, [main_table_id, temp_table_id])
+
+    def test_finalize_full_refresh_live(self, streaming_v2_config, bq_client, test_run_id):
+        """Test finalize() for FULL_REFRESH mode with real BigQuery tables."""
+        sync_metadata = create_sync_metadata(SourceSyncModes.FULL_REFRESH, test_run_id)
+
+        destination = BigQueryStreamingV2Destination(
+            sync_metadata=sync_metadata,
+            config=streaming_v2_config,
+            backend=MagicMock(),
+            source_callback=MagicMock(),
+            monitor=MagicMock(),
+        )
+
+        main_table_id = destination.table_id
+        temp_table_id = destination.temp_table_id
+
+        try:
+            # Create schema
+            schema = [
+                bigquery.SchemaField("_source_record_id", "STRING", mode="REQUIRED"),
+                bigquery.SchemaField("_source_timestamp", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField("_source_data", "JSON", mode="NULLABLE"),
+                bigquery.SchemaField("_bizon_extracted_at", "TIMESTAMP", mode="REQUIRED"),
+                bigquery.SchemaField(
+                    "_bizon_loaded_at", "TIMESTAMP", mode="REQUIRED", default_value_expression="CURRENT_TIMESTAMP()"
+                ),
+                bigquery.SchemaField("_bizon_id", "STRING", mode="REQUIRED"),
+            ]
+
+            # Create temp table with fresh data
+            temp_table = bigquery.Table(temp_table_id, schema=schema)
+            bq_client.create_table(temp_table, exists_ok=True)
+
+            # Insert row into temp table
+            rows = [
+                {
+                    "_source_record_id": "fresh_1",
+                    "_source_timestamp": datetime.now(tz=UTC).isoformat(),
+                    "_source_data": '{"key": "fresh"}',
+                    "_bizon_extracted_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_loaded_at": datetime.now(tz=UTC).isoformat(),
+                    "_bizon_id": "bizon_fresh_1",
+                }
+            ]
+            bq_client.insert_rows_json(temp_table_id, rows)
+
+            # Wait for streaming buffer
+            time.sleep(2)
+
+            # Run finalize
+            result = destination.finalize()
+
+            assert result is True
+
+            # Verify temp table was deleted
+            with pytest.raises(NotFound):
+                bq_client.get_table(temp_table_id)
+
+            # Verify main table exists with data
+            query = f"SELECT COUNT(*) as count FROM `{main_table_id}`"
+            query_job = bq_client.query(query)
+            results = list(query_job.result())
+            assert results[0].count == 1
+
+        finally:
+            cleanup_tables(bq_client, [main_table_id, temp_table_id])

--- a/tests/engine/test_producer_incremental.py
+++ b/tests/engine/test_producer_incremental.py
@@ -1,6 +1,5 @@
 import os
-import threading
-from datetime import datetime, timedelta
+from datetime import datetime
 from queue import Queue
 
 import pytest
@@ -11,7 +10,7 @@ from bizon.engine.backend.models import JobStatus, StreamJob
 from bizon.engine.engine import RunnerFactory
 from bizon.engine.pipeline.producer import Producer
 from bizon.source.config import SourceSyncModes
-from bizon.source.models import SourceIncrementalState, SourceIteration, SourceRecord
+from bizon.source.models import SourceIncrementalState
 
 
 @pytest.fixture(scope="function")

--- a/tests/engine/test_producer_incremental.py
+++ b/tests/engine/test_producer_incremental.py
@@ -1,0 +1,133 @@
+import os
+import threading
+from datetime import datetime, timedelta
+from queue import Queue
+
+import pytest
+from pytz import UTC
+
+from bizon.engine.backend.backend import AbstractBackend
+from bizon.engine.backend.models import JobStatus, StreamJob
+from bizon.engine.engine import RunnerFactory
+from bizon.engine.pipeline.producer import Producer
+from bizon.source.config import SourceSyncModes
+from bizon.source.models import SourceIncrementalState, SourceIteration, SourceRecord
+
+
+@pytest.fixture(scope="function")
+def incremental_producer(my_sqlite_backend: AbstractBackend):
+    """Create a producer with incremental sync mode."""
+    runner = RunnerFactory.create_from_yaml(os.path.abspath("tests/engine/dummy_pipeline_sqlite.yml"))
+    # Override sync_mode to INCREMENTAL
+    runner.bizon_config.source.sync_mode = SourceSyncModes.INCREMENTAL
+    runner.bizon_config.source.cursor_field = "updated_at"
+
+    source = runner.get_source(bizon_config=runner.bizon_config, config=runner.config)
+    my_sqlite_backend.create_all_tables()
+    queue = runner.get_queue(bizon_config=runner.bizon_config, queue=Queue())
+    return Producer(bizon_config=runner.bizon_config, queue=queue, source=source, backend=my_sqlite_backend)
+
+
+@pytest.fixture(scope="function")
+def previous_successful_job(incremental_producer: Producer, sqlite_db_session) -> StreamJob:
+    """Create a previous successful job for incremental testing."""
+    job = incremental_producer.backend.create_stream_job(
+        name=incremental_producer.bizon_config.name,
+        source_name=incremental_producer.source.config.name,
+        stream_name=incremental_producer.source.config.stream,
+        sync_mode=SourceSyncModes.INCREMENTAL.value,
+        job_status=JobStatus.SUCCEEDED,
+        session=sqlite_db_session,
+    )
+    return job
+
+
+def test_incremental_sync_mode_detection(incremental_producer: Producer):
+    """Test that the producer correctly detects incremental sync mode."""
+    assert incremental_producer.bizon_config.source.sync_mode == SourceSyncModes.INCREMENTAL
+
+
+def test_incremental_cursor_field_set(incremental_producer: Producer):
+    """Test that cursor_field is correctly set in bizon config."""
+    # cursor_field is set in bizon_config.source, not the source's own config
+    assert incremental_producer.bizon_config.source.cursor_field == "updated_at"
+
+
+def test_incremental_first_run_fallback(incremental_producer: Producer, sqlite_db_session):
+    """Test that first incremental run falls back to full refresh behavior when no previous job exists."""
+    # Create a new job (not a previous successful one)
+    job = incremental_producer.backend.create_stream_job(
+        name=incremental_producer.bizon_config.name,
+        source_name=incremental_producer.source.config.name,
+        stream_name=incremental_producer.source.config.stream,
+        sync_mode=SourceSyncModes.INCREMENTAL.value,
+        job_status=JobStatus.STARTED,
+        session=sqlite_db_session,
+    )
+
+    # Verify no previous successful job exists
+    last_successful = incremental_producer.backend.get_last_successful_stream_job(
+        name=incremental_producer.bizon_config.name,
+        source_name=incremental_producer.source.config.name,
+        stream_name=incremental_producer.source.config.stream,
+    )
+    assert last_successful is None
+
+
+def test_incremental_with_previous_job(incremental_producer: Producer, previous_successful_job: StreamJob):
+    """Test that incremental mode finds the previous successful job."""
+    last_successful = incremental_producer.backend.get_last_successful_stream_job(
+        name=incremental_producer.bizon_config.name,
+        source_name=incremental_producer.source.config.name,
+        stream_name=incremental_producer.source.config.stream,
+    )
+
+    assert last_successful is not None
+    assert last_successful.id == previous_successful_job.id
+    assert last_successful.status == JobStatus.SUCCEEDED
+
+
+def test_source_incremental_state_creation(incremental_producer: Producer, previous_successful_job: StreamJob):
+    """Test that SourceIncrementalState is created correctly."""
+    last_successful = incremental_producer.backend.get_last_successful_stream_job(
+        name=incremental_producer.bizon_config.name,
+        source_name=incremental_producer.source.config.name,
+        stream_name=incremental_producer.source.config.stream,
+    )
+
+    # Create the incremental state as the producer would (using bizon_config.source.cursor_field)
+    source_incremental_state = SourceIncrementalState(
+        last_run=last_successful.created_at,
+        state={},
+        cursor_field=incremental_producer.bizon_config.source.cursor_field,
+    )
+
+    assert source_incremental_state.last_run == last_successful.created_at
+    assert source_incremental_state.state == {}
+    assert source_incremental_state.cursor_field == "updated_at"
+
+
+def test_source_incremental_state_model():
+    """Test SourceIncrementalState model validation."""
+    now = datetime.now(tz=UTC)
+
+    state = SourceIncrementalState(
+        last_run=now,
+        state={"custom_key": "custom_value"},
+        cursor_field="modified_at",
+    )
+
+    assert state.last_run == now
+    assert state.state == {"custom_key": "custom_value"}
+    assert state.cursor_field == "modified_at"
+
+
+def test_source_incremental_state_default_values():
+    """Test SourceIncrementalState default values."""
+    now = datetime.now(tz=UTC)
+
+    state = SourceIncrementalState(last_run=now)
+
+    assert state.last_run == now
+    assert state.state == {}
+    assert state.cursor_field is None


### PR DESCRIPTION
## Summary
- Implement `get_records_after()` for incremental sync in Notion source
- Add incremental sync support to BigQuery and BigQuery Streaming V2 destinations
- Update documentation with incremental sync implementation guide
- Bump version to 0.2.0

## Test plan
- [ ] Run existing tests with `uv run pytest`
- [ ] Test incremental sync with Notion source manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)